### PR TITLE
Add support for Supported Payment Methods endpoint.

### DIFF
--- a/client.go
+++ b/client.go
@@ -219,3 +219,8 @@ func (c *Client) Refund() *RefundClient {
 func (c *Client) Redirection() *RedirectionClient {
 	return &RedirectionClient{Caller: c}
 }
+
+// SupportedPaymentMethods creates client to work with SupportedPaymentMethod entity list.
+func (c *Client) SupportedPaymentMethods() *SupportedPaymentMethodClient {
+	return &SupportedPaymentMethodClient{Caller: c}
+}

--- a/common.go
+++ b/common.go
@@ -2,11 +2,18 @@ package zooz
 
 // Result represents status and category of some methods response.
 type Result struct {
-	Status      string `json:"status"`
-	Category    string `json:"category"`
-	SubCategory string `json:"sub_category"`
-	Description string `json:"description"`
+	Status      ResultStatus `json:"status"`
+	Category    string       `json:"category"`
+	SubCategory string       `json:"sub_category"`
+	Description string       `json:"description"`
 }
+
+type ResultStatus string
+
+const (
+	StatusSucceed ResultStatus = "Succeed"
+	StatusFailed  ResultStatus = "Failed"
+)
 
 // ClientInfo represents optional request params for some methods.
 type ClientInfo struct {

--- a/supported_payment_method.go
+++ b/supported_payment_method.go
@@ -1,0 +1,66 @@
+package zooz
+
+import (
+	"context"
+	"net/http"
+)
+
+const supportedPaymentMethodsPath = "supported-payment-methods"
+
+type SupportedPaymentMethodClient struct {
+	Caller Caller
+}
+
+type SupportedPaymentMethod struct {
+	ConfigurationID         string              `json:"configuration_id"`
+	ConfigurationName       string              `json:"configuration_name"`
+	ProviderID              string              `json:"provider_id"`
+	ProviderName            string              `json:"provider_name"`
+	SupportedPaymentMethods []PaymentMethodData `json:"supported_payment_methods"`
+	Result                  Result              `json:"result"`
+}
+
+type PaymentMethodData struct {
+	DisplayName string                  `json:"display_name"`
+	Vendor      string                  `json:"vendor"`
+	SourceType  SourceType              `json:"source_type"`
+	Status      PaymentMethodDataStatus `json:"status"`
+	Country     string                  `json:"country"`
+	LogoURL     string                  `json:"logo_url"`
+	Amounts     []Amount                `json:"amounts"`
+}
+
+type SourceType string
+
+const (
+	BankTransfer SourceType = "bank_transfer"
+	Cash         SourceType = "cash"
+	Ewallet      SourceType = "ewallet"
+	DebitDirect  SourceType = "debit_redirect"
+	Loyalty      SourceType = "loyalty"
+	CreditCard   SourceType = "credit_card"
+	Credit       SourceType = "credit"
+)
+
+type PaymentMethodDataStatus string
+
+const (
+	PMStatusAvailable            PaymentMethodDataStatus = "available"
+	PMStatusTemporaryUnavailable PaymentMethodDataStatus = "temporarily_unavailable"
+	PMStatusDisabled             PaymentMethodDataStatus = "disabled"
+)
+
+type Amount struct {
+	Min      int64  `json:"min"`
+	Max      int64  `json:"max"`
+	Currency string `json:"currency"`
+}
+
+func (c *SupportedPaymentMethodClient) Get(ctx context.Context) ([]SupportedPaymentMethod, error) {
+	var spms []SupportedPaymentMethod
+	err := c.Caller.Call(ctx, http.MethodGet, supportedPaymentMethodsPath, nil, nil, &spms)
+	if err != nil {
+		return nil, err
+	}
+	return spms, nil
+}

--- a/supported_payment_method_test.go
+++ b/supported_payment_method_test.go
@@ -1,0 +1,47 @@
+package zooz
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestSupportedPaymentMethodClient_Get(t *testing.T) {
+	spms := []SupportedPaymentMethod{
+		{
+			ConfigurationID:         "conf-id",
+			ConfigurationName:       "conf-name",
+			ProviderID:              "provider-id",
+			ProviderName:            "provider-name",
+			SupportedPaymentMethods: []PaymentMethodData{},
+			Result: Result{
+				Status: StatusFailed,
+			},
+		},
+	}
+
+	caller := &callerMock{
+		t:               t,
+		expectedMethod:  http.MethodGet,
+		expectedPath:    "supported-payment-methods",
+		expectedHeaders: nil,
+		expectedReqObj:  nil,
+		returnRespObj:   &spms,
+	}
+
+	c := &SupportedPaymentMethodClient{Caller: caller}
+
+	res, err := c.Get(context.Background())
+
+	if err != nil {
+		t.Error("Error must be nil")
+	}
+	if res == nil {
+		t.Errorf("Supported payment methods is nil")
+	}
+
+	if !reflect.DeepEqual(res, spms) {
+		t.Errorf("Result is not equal to expected: \n%+v, \n%+v", res, spms)
+	}
+}


### PR DESCRIPTION
Integrating: https://developers.paymentsos.com/docs/api/#tag/Supported-Payment-Methods

I'm not a fan of the naming, but the descriptors grew and grew so I tried to keep them as concise as possible.